### PR TITLE
Add support for by-name parameters

### DIFF
--- a/core/src/main/scala/eu/monniot/scala3mock/macros/WhenImpl.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/macros/WhenImpl.scala
@@ -20,10 +20,13 @@ private[scala3mock] object WhenImpl:
       val mf = ${createMockFunction(f)}.asInstanceOf[MockFunction1[T1, R]]
 
       // used to debug what it is being infered
-      //println(s"selected MockFunction1 = $mf")
-      //println(s"T1 = " + ${Expr(Type.show[T1])})
-      //println(s"R =  " + ${Expr(Type.show[R])})
-
+      /*
+      println(s"""|selected MockFunction1 = $mf
+                  |T1 = ${${Expr(Type.show[T1])}}
+                  |T1.repr = ${${Expr(TypeRepr.of[T1].toString())}}
+                  |R = ${${Expr(Type.show[R])}}
+                  |""".stripMargin)
+      */
       mf
     }
 
@@ -127,7 +130,7 @@ private[scala3mock] object WhenImpl:
                 // If there are no overload, let's use the method name as the mock key. Otherwise
                 // append the index of the overload. Using the same sort here and in the mock
                 // declaration is important for the indices to match.
-                if overload.length == 1 then name
+                if overload.length < 2 then name
                 else {
                   val idx = overload.indexWhere(_.signature == signature)
 

--- a/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
+++ b/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
@@ -77,10 +77,14 @@ class MockSuite extends munit.FunSuite with MockFunctions {
       when(m.repeatedParam _).expects(0, Seq.empty).returning("hello")
       assertEquals(m.repeatedParam(0), "hello")
 
-      // TODO Not supported yet
-      // https://github.com/fmonniot/scala3mock/issues/4
-      // when(m.byNameParam).expects(3).returns("ok")
-      // assertEquals(m.byNameParam(3), "ok")
+      // Partially supported. Issue with type inference still. See https://github.com/fmonniot/scala3mock/issues/4
+      // Interestingly enough here if we do not force the types, the compiler will happily
+      // infer a type `((=> Int) => String)` which doesn't matches any of our `when` declarations.
+      // This can also be fixed by having the when/WhenImpl macros takes a by-name parameter. That
+      // second solution isn't very practical for 3+ matchers as it would explode the number of overload
+      // required to match all possible cases.
+      when[Int, String](m.byNameParam).expects(3).returns("ok")
+      assertEquals(m.byNameParam(3), "ok")
 
       // implicit parameters
       given y: Double = 1.23

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -21,4 +21,4 @@ title: Installation
 - No cross compilation with Scala2
 - Support for ScalaTest's `path.FunSpec` removed (help welcome)
 - Support for inner types ([help welcome](https://github.com/fmonniot/scala3mock/issues/3))
-- Support for by-name parameters ([help welcome](https://github.com/fmonniot/scala3mock/issues/4))
+- By-name parameters ([help welcome](https://github.com/fmonniot/scala3mock/issues/4)) currently have issues with type inference, but work fine when fully specifiying types when defining the expectations (eg. `when[String, Int](mock.function).expects("val").returns(1)`)


### PR DESCRIPTION
This partially resolve #4. By-name parameters are supported by the library, but there is still a type inference issue when using the `when` macro and not specifying the type explicitely.