### PR TITLE
Fix artifacts name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val scala3mock = project
 lazy val core = project
   .in(file("./core"))
   .settings(
-    name := "scala3mock-core",
+    name := "scala3mock",
     scalacOptions ++= Seq("-feature", "-explain"),
     Test / scalacOptions += "-Xcheck-macros",
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ ThisBuild / developers := List(
 lazy val scala3mock = project
   .in(file("."))
   .aggregate(core, scalatest)
+  .settings(publish/skip := true)
 
 lazy val core = project
   .in(file("./core"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0
+sbt.version=1.9.6


### PR DESCRIPTION
This should resolve the confusion created by the current mismatch between the documentation stating to use `scala3mock` and the build process publishing `scala3mock-core` (the actual jar) and `scala3mock` (the aggregate project, an empty jar).