### PR TITLE
Use public constructor & Default type class for default values

### DIFF
--- a/core/src/main/scala/eu/monniot/scala3mock/macros/macros.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/macros/macros.scala
@@ -7,6 +7,12 @@ import eu.monniot.scala3mock.main.Default
 trait Mocks:
   inline def mock[T](using MockContext): T = MockImpl[T]
 
+  /** Like mock but enable internal debug log for our macros. Use when you have
+    * found an issue and want to report it to the maintainers.
+    */
+  inline def mockWithDebuggingOutput[T](using MockContext): T =
+    MockImpl.debug[T]
+
   import scala.quoted.*
 
   // The Default constraint on the return type somehow help the compiler

--- a/core/src/main/scala/eu/monniot/scala3mock/main/Default.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/main/Default.scala
@@ -3,7 +3,10 @@ package eu.monniot.scala3mock.main
 /** Provides a default value for some type. This is used for mocked functions to
   * return something if no specific value have beeen provided.
   *
-  * Note that `Any` doesn't have any default at the moment.
+  * Note that `Any` doesn't have any default at the moment. If you decide to
+  * implement `Default` for your own type, do note that the library's mock macro
+  * currently doesn't support higher-kinded types and default to `null` for
+  * those. If this is necessary for you, we welcome Pull Requests!
   */
 trait Default[A]:
   val default: A
@@ -27,8 +30,4 @@ object Default:
   given Default[java.io.OutputStream] with {
     val default = java.io.OutputStream.nullOutputStream()
   }
-
-  // Note that our macro currently doesn't support Default instances of higher kinded types and instead
-  // uses `null` literal for those. If we want to add support for those here, we will need to improve
-  // our macro system first.
   given [Y]: Default[Y] with { val default = null.asInstanceOf[Y] }

--- a/core/src/main/scala/eu/monniot/scala3mock/main/Default.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/main/Default.scala
@@ -24,4 +24,11 @@ object Default:
   given Default[Unit] with { val default = () }
 
   // AnyRef
+  given Default[java.io.OutputStream] with {
+    val default = java.io.OutputStream.nullOutputStream()
+  }
+
+  // Note that our macro currently doesn't support Default instances of higher kinded types and instead
+  // uses `null` literal for those. If we want to add support for those here, we will need to improve
+  // our macro system first.
   given [Y]: Default[Y] with { val default = null.asInstanceOf[Y] }

--- a/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
+++ b/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
@@ -282,4 +282,21 @@ class MockSuite extends munit.FunSuite with MockFunctions {
       m.print("hello")
     }
   }
+
+  test("User's can define their own Default value") {
+    case class MyType(s: String)
+    given Default[MyType] with { val default = MyType("testing") }
+
+    trait MyService {
+      def service(): MyType
+    }
+
+    withExpectations() {
+      val m = mock[MyService]
+
+      when(() => m.service()).expects()
+
+      assertEquals(m.service(), MyType("testing"))
+    }
+  }
 }

--- a/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
+++ b/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
@@ -273,4 +273,13 @@ class MockSuite extends munit.FunSuite with MockFunctions {
       assert(m.isInstanceOf[ClassWithoutTypeParameters])
     }
   }
+
+  test("PrintStream - class with private constructor - issue #15") {
+    withExpectations() {
+      val m = mock[java.io.PrintStream]
+
+      when(m.print(_: String)).expects("hello")
+      m.print("hello")
+    }
+  }
 }


### PR DESCRIPTION
This PR does a few things:

1. Instead of using a type primary constructor (that might be private), we search for the first public one. If no public constructors are found, we emit an error to let the user know they can't mock this type.
2. The default value handling for mocked `val` and constructor call is now using the `Default` type class. That means we can more easily add support for specific types that we know don't work well when `null`ed by default (like `OutputStream` which is checked by quite a few Java constructors).

Together, those two improvements should solve the issue raised in #15.