### PR TITLE
Better mock names

### DIFF
--- a/core/src/main/scala/eu/monniot/scala3mock/context/MockContext.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/context/MockContext.scala
@@ -38,4 +38,4 @@ trait MockContext:
     )
 
   def errorContext(callLog: ListBuffer[Call], expectationContext: Handlers) =
-    s"Expected:\n$expectationContext\n\nActual:\n$callLog"
+    s"Expected:\n$expectationContext\n\nActual:\n${callLog.mkString("  ", "\n  ", "")}"

--- a/core/src/main/scala/eu/monniot/scala3mock/macros/MockImpl.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/macros/MockImpl.scala
@@ -133,10 +133,14 @@ private class MockImpl[T](ctx: Expr[MockContext], debug: Boolean)(using
       // from the mock's Map keys (which is what mockName refer to). It includes a few
       // more information to make it more user friendly.
       val pos = Position.ofMacroExpansion
-      val mockToStringName = s"<${pos.sourceFile.name}#L${pos.startLine}> $mockedClassName.${sym.name}"
+      val mockToStringName =
+        s"<${pos.sourceFile.name}#L${pos.startLine}> $mockedClassName.${sym.name}"
 
-      val createMF =  
-        Apply(newMockFunction, List(ctxTerm, Literal(StringConstant(mockToStringName))))
+      val createMF =
+        Apply(
+          newMockFunction,
+          List(ctxTerm, Literal(StringConstant(mockToStringName)))
+        )
           .appliedTo(defaultTypeClass.tree)
 
       val tuple2Sym = defn.TupleClass(2)

--- a/core/src/main/scala/eu/monniot/scala3mock/macros/MockImpl.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/macros/MockImpl.scala
@@ -132,7 +132,8 @@ private class MockImpl[T](ctx: Expr[MockContext], debug: Boolean)(using
       // The name of the mock as passed to the MockFunctionX trait is slightly different
       // from the mock's Map keys (which is what mockName refer to). It includes a few
       // more information to make it more user friendly.
-      val mockToStringName = mockedClassName + "." + sym.name
+      val pos = Position.ofMacroExpansion
+      val mockToStringName = s"<${pos.sourceFile.name}#L${pos.startLine}> $mockedClassName.${sym.name}"
 
       val createMF =  
         Apply(newMockFunction, List(ctxTerm, Literal(StringConstant(mockToStringName))))

--- a/core/src/main/scala/eu/monniot/scala3mock/macros/MockImpl.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/macros/MockImpl.scala
@@ -133,8 +133,16 @@ private class MockImpl[T](ctx: Expr[MockContext], debug: Boolean)(using
       // from the mock's Map keys (which is what mockName refer to). It includes a few
       // more information to make it more user friendly.
       val pos = Position.ofMacroExpansion
+      // For now I'm going to assume that there can only be one type parameter list. That might
+      // be (or become) wrong but it does simplify the name generation quite a bit.
+      val typeParameters =
+        val tpe = sym.paramSymss.filter(_.exists(_.isType)).flatten
+
+        if tpe.isEmpty then ""
+        else tpe.map(_.typeRef.show).mkString("[", ",", "]")
+
       val mockToStringName =
-        s"<${pos.sourceFile.name}#L${pos.startLine}> $mockedClassName.${sym.name}"
+        s"<${pos.sourceFile.name}#L${pos.startLine}> $mockedClassName.${sym.name}${typeParameters}"
 
       val createMF =
         Apply(

--- a/scalatest/src/test/scala/eu/monniot/scala3mock/scalatest/ErrorReportingTest.scala
+++ b/scalatest/src/test/scala/eu/monniot/scala3mock/scalatest/ErrorReportingTest.scala
@@ -107,14 +107,13 @@ class ErrorReportingTest
 
     val outcome = runTestCase[TestedSuite](new TestedSuite)
     val errorMessage = getErrorMessage[TestFailedException](outcome)
-    // TODO Missing the type parameters on polymorphicMethod expected (`*Method[T](List(1))`)
     errorMessage shouldBe
       """|Unexpected call: <ErrorReportingTest.scala#L99> TestTrait.oneParamMethod(3)
          |
          |Expected:
          |inAnyOrder {
          |  <ErrorReportingTest.scala#L92> OuterTestTrait.noParamMethod() twice (called once - UNSATISFIED)
-         |  <ErrorReportingTest.scala#L99> TestTrait.polymorphicMethod(List(1)) once (never called - UNSATISFIED)
+         |  <ErrorReportingTest.scala#L99> TestTrait.polymorphicMethod[T](List(1)) once (never called - UNSATISFIED)
          |}
          |
          |Actual:

--- a/scalatest/src/test/scala/eu/monniot/scala3mock/scalatest/ErrorReportingTest.scala
+++ b/scalatest/src/test/scala/eu/monniot/scala3mock/scalatest/ErrorReportingTest.scala
@@ -59,7 +59,7 @@ class ErrorReportingTest
     getThrowable[NullPointerException](outcome) shouldBe a[NullPointerException]
   }
 
-  it should "report default mock names" in pendingUntilFixed {
+  it should "report default mock names" in {
     class TestedSuite extends AnyFunSuite with MockFactory {
       test("execute block of code") {
         val mockA = mock[TestTrait]
@@ -73,21 +73,22 @@ class ErrorReportingTest
     val outcome = runTestCase[TestedSuite](new TestedSuite)
     val errorMessage = getErrorMessage[TestFailedException](outcome)
     errorMessage shouldBe
-      """|Unexpected call: <mock-2> TestTrait.oneParamMethod(3)
+      """|Unexpected call: <ErrorReportingTest.scala#L65> TestTrait.oneParamMethod(3)
         |
         |Expected:
         |inAnyOrder {
-        |  <mock-1> TestTrait.oneParamMethod(3) once (never called - UNSATISFIED)
+        |  <ErrorReportingTest.scala#L64> TestTrait.oneParamMethod(3) once (never called - UNSATISFIED)
         |}
         |
         |Actual:
-        |  <mock-2> TestTrait.oneParamMethod(3)
+        |  <ErrorReportingTest.scala#L65> TestTrait.oneParamMethod(3)
       """.stripMargin.trim
   }
 
-  it should "report unexpected calls in readable manner" in pendingUntilFixed {
-    trait OuterTestTrait
-        extends TestTrait // To have a different name being reported
+  it should "report unexpected calls in readable manner" in {
+    // To have a different name being reported
+    trait OuterTestTrait extends TestTrait
+
     class TestedSuite extends AnyFunSuite with MockFactory {
       val suiteScopeMock = mock[OuterTestTrait]
       when(() => suiteScopeMock.noParamMethod())
@@ -106,18 +107,19 @@ class ErrorReportingTest
 
     val outcome = runTestCase[TestedSuite](new TestedSuite)
     val errorMessage = getErrorMessage[TestFailedException](outcome)
+    // TODO Missing the type parameters on polymorphicMethod expected (`*Method[T](List(1))`)
     errorMessage shouldBe
-      """|Unexpected call: <mock-1> TestTrait.oneParamMethod(3)
+      """|Unexpected call: <ErrorReportingTest.scala#L99> TestTrait.oneParamMethod(3)
          |
          |Expected:
          |inAnyOrder {
-         |  <suite mock> TestTrait.noParamMethod() twice (called once - UNSATISFIED)
-         |  <mock-1> TestTrait.polymorphicMethod[T](List(1)) once (never called - UNSATISFIED)
+         |  <ErrorReportingTest.scala#L92> OuterTestTrait.noParamMethod() twice (called once - UNSATISFIED)
+         |  <ErrorReportingTest.scala#L99> TestTrait.polymorphicMethod(List(1)) once (never called - UNSATISFIED)
          |}
          |
          |Actual:
-         |  <suite mock> TestTrait.noParamMethod()
-         |  <mock-1> TestTrait.oneParamMethod(3)
+         |  <ErrorReportingTest.scala#L92> OuterTestTrait.noParamMethod()
+         |  <ErrorReportingTest.scala#L99> TestTrait.oneParamMethod(3)
       """.stripMargin.trim
   }
 }


### PR DESCRIPTION
This address and fix https://github.com/fmonniot/scala3mock/issues/8.

We are doing it a bit differently from the original ScalaMock. They have an increasing counter stored in the mock counter. This is great to distinguish mocks of the same class based on their declaration order, but you still have to track down which one you defined first.

Instead what we are doing here is to rely on the position within the source code where the mock was defined. This is a bit more verbose, but instantanely inform the user on which mock they are looking at. An example of such error is as follow:

```
Unexpected call: <ErrorReportingTest.scala#L99> TestTrait.oneParamMethod(3)

Expected:
inAnyOrder {
  <ErrorReportingTest.scala#L92> OuterTestTrait.noParamMethod() twice (called once - UNSATISFIED)
  <ErrorReportingTest.scala#L99> TestTrait.polymorphicMethod(List(1)) once (never called - UNSATISFIED)
}

Actual:
  <ErrorReportingTest.scala#L92> OuterTestTrait.noParamMethod()
  <ErrorReportingTest.scala#L99> TestTrait.oneParamMethod(3)
```