### PR TITLE
Cats support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,8 +47,13 @@ lazy val cats = project
   .in(file("./cats"))
   .dependsOn(core)
   .settings(
-    name := "scala3mock-scalatest",
-    libraryDependencies += "org.typelevel" %% "cats-core" % "2.9.0"
+    name := "scala3mock-cats",
+    libraryDependencies += "org.typelevel" %% "cats-core" % "2.9.0",
+
+    libraryDependencies ++= Seq(
+      "org.scalameta" %% "munit" % "1.0.0-M10" % Test,
+      "org.typelevel" %% "cats-effect" % "3.5.2" % Test
+    )
   )
 
 lazy val scalatest = project

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ ThisBuild / developers := List(
 
 lazy val scala3mock = project
   .in(file("."))
-  .aggregate(core, scalatest)
+  .aggregate(core, cats, scalatest)
   .settings(publish / skip := true)
 
 lazy val core = project
@@ -41,6 +41,14 @@ lazy val core = project
     // Test / scalacOptions += "-Yretain-trees", // For debugging when writing macros
 
     libraryDependencies += "org.scalameta" %% "munit" % "1.0.0-M10" % Test
+  )
+
+lazy val cats = project
+  .in(file("./cats"))
+  .dependsOn(core)
+  .settings(
+    name := "scala3mock-scalatest",
+    libraryDependencies += "org.typelevel" %% "cats-core" % "2.9.0"
   )
 
 lazy val scalatest = project

--- a/build.sbt
+++ b/build.sbt
@@ -66,11 +66,12 @@ lazy val scalatest = project
 
 lazy val docs = project
   .in(file("site-docs")) // important: it must not be docs/
-  .dependsOn(core, scalatest)
+  .dependsOn(core, cats, scalatest)
   .enablePlugins(MdocPlugin, DocusaurusPlugin)
   .settings(
     publish / skip := true,
     mdocVariables := Map(
       "VERSION" -> (core / version).value
-    )
+    ),
+    libraryDependencies += "org.typelevel" %% "cats-effect" % "3.5.2"
   )

--- a/cats/src/main/scala/eu/monniot/scala3mock/cats/ScalaMocks.scala
+++ b/cats/src/main/scala/eu/monniot/scala3mock/cats/ScalaMocks.scala
@@ -10,8 +10,6 @@ import scala.annotation.unused
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 
-
-
 object ScalaMocks extends ScalaMocks
 
 /** Helper trait that provide access to all components (mandatory or optional)
@@ -26,9 +24,9 @@ trait ScalaMocks
   // parameter. That might have been fixed in 3.3+, but we can't use
   // that version so for now we will duplicate the definition.
   def withExpectations[F[_], A](verifyAfterRun: Boolean = true)(
-    f: MockContext ?=> F[A]
-)(using MonadError[F, Throwable]): F[A] = eu.monniot.scala3mock.cats.withExpectations(verifyAfterRun)(f)
-
+      f: MockContext ?=> F[A]
+  )(using MonadError[F, Throwable]): F[A] =
+    eu.monniot.scala3mock.cats.withExpectations(verifyAfterRun)(f)
 
 // A standalone function to run a test with a mock context, asserting all expectations at the end.
 def withExpectations[F[_], A](verifyAfterRun: Boolean = true)(
@@ -69,8 +67,6 @@ def withExpectations[F[_], A](verifyAfterRun: Boolean = true)(
       try
         verifyExpectations()
         me.pure(a)
-      catch
-        case t => me.raiseError(t)
-    else
-      me.pure(a)
+      catch case t => me.raiseError(t)
+    else me.pure(a)
   }

--- a/cats/src/main/scala/eu/monniot/scala3mock/cats/package.scala
+++ b/cats/src/main/scala/eu/monniot/scala3mock/cats/package.scala
@@ -1,0 +1,55 @@
+package eu.monniot.scala3mock.cats
+
+import cats.MonadError
+import eu.monniot.scala3mock.context.{Call, MockContext}
+import eu.monniot.scala3mock.functions.MockFunction1
+import eu.monniot.scala3mock.handlers.{CallHandler, Handler, UnorderedHandlers}
+import eu.monniot.scala3mock.main.TestExpectationEx
+
+import scala.annotation.unused
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+
+
+// A standalone function to run a test with a mock context, asserting all expectations at the end.
+def withExpectations[F[_], A](verifyAfterRun: Boolean = true)(
+    f: MockContext ?=> F[A]
+)(using MonadError[F, Throwable]): F[A] =
+
+  val ctx = new MockContext:
+    override type ExpectationException = TestExpectationEx
+
+    override def newExpectationException(
+        message: String,
+        methodName: Option[String]
+    ): ExpectationException =
+      new TestExpectationEx(message, methodName)
+
+    override def toString() = s"MockContext(callLog = $callLog)"
+
+  def initializeExpectations(): Unit =
+    val initialHandlers = new UnorderedHandlers
+
+    ctx.callLog = new ListBuffer[Call]
+    ctx.expectationContext = initialHandlers
+
+  def verifyExpectations(): Unit =
+    ctx.callLog foreach ctx.expectationContext.verify _
+
+    val oldCallLog = ctx.callLog
+    val oldExpectationContext = ctx.expectationContext
+
+    if !oldExpectationContext.isSatisfied then
+      ctx.reportUnsatisfiedExpectation(oldCallLog, oldExpectationContext)
+
+  try
+    initializeExpectations()
+    MonadError[F, Throwable] // TODO Wire the result and verification correctly
+    val result = f(using ctx)
+    if verifyAfterRun then verifyExpectations()
+    result
+  catch
+    case NonFatal(ex) =>
+      // do not verify expectations - just clear them. Throw original exception
+      // see issue #72
+      throw ex

--- a/cats/src/test/scala/eu/monniot/scala3mock/cats/CatsSuite.scala
+++ b/cats/src/test/scala/eu/monniot/scala3mock/cats/CatsSuite.scala
@@ -4,18 +4,18 @@ import cats.effect.SyncIO
 
 class CatsSuite extends munit.FunSuite with ScalaMocks {
 
-    test("it should validate expectations after a lazy data type evaluated") {
-        // An implicit assumption of this code block is that the expectations
-        // are not validated on exit of the `withExpectations` function but when
-        // the returned Monad is being evaluated.
-        val fa = withExpectations() {
-            val intToStringMock = mockFunction[Int, String]
-            intToStringMock.expects(*)
+  test("it should validate expectations after a lazy data type evaluated") {
+    // An implicit assumption of this code block is that the expectations
+    // are not validated on exit of the `withExpectations` function but when
+    // the returned Monad is being evaluated.
+    val fa = withExpectations() {
+      val intToStringMock = mockFunction[Int, String]
+      intToStringMock.expects(*)
 
-            SyncIO(intToStringMock(2))
-        }
-
-        assertEquals(fa.unsafeRunSync(), null)
+      SyncIO(intToStringMock(2))
     }
-  
+
+    assertEquals(fa.unsafeRunSync(), null)
+  }
+
 }

--- a/cats/src/test/scala/eu/monniot/scala3mock/cats/CatsSuite.scala
+++ b/cats/src/test/scala/eu/monniot/scala3mock/cats/CatsSuite.scala
@@ -1,0 +1,21 @@
+package eu.monniot.scala3mock.cats
+
+import cats.effect.SyncIO
+
+class CatsSuite extends munit.FunSuite with ScalaMocks {
+
+    test("it should validate expectations after a lazy data type evaluated") {
+        // An implicit assumption of this code block is that the expectations
+        // are not validated on exit of the `withExpectations` function but when
+        // the returned Monad is being evaluated.
+        val fa = withExpectations() {
+            val intToStringMock = mockFunction[Int, String]
+            intToStringMock.expects(*)
+
+            SyncIO(intToStringMock(2))
+        }
+
+        assertEquals(fa.unsafeRunSync(), null)
+    }
+  
+}

--- a/docs/user-guide/cats.md
+++ b/docs/user-guide/cats.md
@@ -1,0 +1,33 @@
+---
+title: Cats Integration
+---
+
+Scala3Mock comes with a Cats integration that provides a `withExpectations` function that work with a `MonadError[?, Throwable]` instead of the simple value that the default library provide. This is pretty useful if your tests are defined in term of monads (Cats-Effect's `IO`, Scala's `Future` via alleycats, etc…).
+
+You'll need to add a new dependency to your **build.sbt**:
+```scala
+libraryDependencies += "eu.monniot" %% "scala3mock-cats" % "@VERSION@" % Test
+```
+
+Once added, simply replace the `ScalaMocks` import with the Cats one:
+
+```diff
+- import eu.monniot.scala3mock.ScalaMocks.*
++ import eu.monniot.scala3mock.cats.ScalaMocks.*
+```
+
+You can then use the library like usual, with the value passed to `withExpectations` being a monad instead of any values.
+
+```scala mdoc
+import eu.monniot.scala3mock.cats.ScalaMocks.*
+import cats.effect.SyncIO
+
+val fa = withExpectations() {
+    val fn = mockFunction[Int, String]
+    fn.expects(*).returns("Hello reader")
+
+    SyncIO(fn(2))
+}
+
+fa.unsafeRunSync()
+```


### PR DESCRIPTION
This PR adds a new module to support Cats-based tests, especially in the case of lazy data types like Cats Effect's IO.