### PR TITLE
Pin dependencies that now require Scala 3.3+

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,9 +1,3 @@
-updates.ignore = [
-    # Let's ignore Scala's 3.3.x serie
-    # see https://github.com/fmonniot/scala3mock/pull/17
-    { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
-]
-
 updates.pin  = [
     # Pinning the dependencies that require 3.3+ to their last known version.
     # This is because the library rely on an experimental API (to create new classes)

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,3 +3,14 @@ updates.ignore = [
     # see https://github.com/fmonniot/scala3mock/pull/17
     { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]
+
+updates.pin  = [
+    # Pinning the dependencies that require 3.3+ to their last known version.
+    # This is because the library rely on an experimental API (to create new classes)
+    # and experimental APIs on 3.3+ now either require a non-stable compiler version
+    # or to pass the `-experimental` config parameter.
+    # This was discovered in https://github.com/fmonniot/scala3mock/pull/50
+    { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.3." },
+    { groupId = "org.typelevel",  artifactId="cats-core",      version = "2.9." },
+    { groupId = "org.scalameta",  artifactId="munit",          version = "1.0.0-M11" }
+]


### PR DESCRIPTION
Let's reduce the number of PR I have to close.

It's honestly not great, but as long as either
- the scala's metaprogramming framework doesn't include a way to create new classes without experimental APIs, or
- the decision to mandate an experimental flag/compiler to use experimental APIs is reverted

we can't really upgrade the compiler.

The "good" news is that this library doesn't really have to depend on other libraries. The core library doesn't have any dependencies so not being able to upgrade our dependencies is not _that_ critical. The cats integration is a nice to have and could be moved to its own thing if comes a point where cats-effect is not backward compatible with 3.5 anymore.