### PR TITLE
Add support for methods with default values

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,10 +28,10 @@ jobs:
           java-version: '11'
       - run: sbt 'docs/mdoc'
   # Note that the first Scala LTS 3.3 is unfortunately not compatible
-  # So we consider 3.2.2 as our baseline until we get a real LTS we
+  # So we consider 3.2.2 as our baseline until we get a LTS we
   # can target.
-  test-lts:
-    name: Test (LTS)
+  test-base:
+    name: Test (3.2.2)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
+++ b/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
@@ -299,4 +299,15 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
     }
   }
 
+  test("TestDefaultParameters - issue #53") {
+    withExpectations() {
+      val m = mock[TestDefaultParameters]
+
+      when(m.foo).expects(9).returns("ok")
+      when(m.foo).expects(42).returns("ok2")
+
+      assertEquals(m.foo(), "ok")
+      assertEquals(m.foo(42), "ok2")
+    }
+  }
 }

--- a/core/src/test/scala/fixtures/TestDefaultParameters.scala
+++ b/core/src/test/scala/fixtures/TestDefaultParameters.scala
@@ -1,0 +1,6 @@
+package fixtures
+
+trait TestDefaultParameters {
+  def foo(bar: Int = 9): String
+  def foo2(b: Int = 1, c: Long): String
+}


### PR DESCRIPTION
This should resolve the issue raised in #53. It turned out that there is no real way to know if a method is generated by the compiler or not (at least on 3.2), so instead I use the fact that default values follow the same naming schemes to exclude them from the list of the methods to override in the mock.