### PR TITLE
Fix default parameters (take 2)

### DIFF
--- a/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
+++ b/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
@@ -306,8 +306,18 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
       when(m.foo).expects(9).returns("ok")
       when(m.foo).expects(42).returns("ok2")
 
+      when(m.multiParamList(_: Int, _: Int)(_: Long, _: Long))
+        .expects(1, 1, 1, 1)
+        .returns("one")
+      when(m.multiParamList(_: Int, _: Int)(_: Long, _: Long))
+        .expects(1, 0, 1, 0)
+        .returns("default")
+
       assertEquals(m.foo(), "ok")
       assertEquals(m.foo(42), "ok2")
+
+      assertEquals(m.multiParamList(1, 1)(1, 1), "one")
+      assertEquals(m.multiParamList(1)(1), "default")
     }
   }
 }

--- a/core/src/test/scala/fixtures/TestDefaultParameters.scala
+++ b/core/src/test/scala/fixtures/TestDefaultParameters.scala
@@ -3,4 +3,9 @@ package fixtures
 trait TestDefaultParameters {
   def foo(bar: Int = 9): String
   def foo2(b: Int = 1, c: Long): String
+
+  def defaultAfterRegular(a: Int, b: Int = 0): String
+  def multiParamList(a: Int, b: Int = 0)(c: Long, d: Long = 0): String
+
+  def withTypeParam[A, B](a: A, b: B)(c: Long, d: Long = 0): String
 }


### PR DESCRIPTION
The number in the generated name is actually the position of the parameter, not an incremented number.