### PR TITLE
Change how we do testing for 3.3+

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,8 +43,8 @@ jobs:
   # We still want to be able to test out the library on newer Scala version.
   # For those version, we compile the library using 3.2 and then run the tests
   # against the newer version. This effectively emulate what our users are doing.
-  test-newer:
-    name: Test (${{ matrix.scalaV }})
+  test-integration:
+    name: Integration Test (${{ matrix.scalaV }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,9 +40,9 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - run: sbt test
-  # We currently depends on a bug fix in 3.4, which at the time this
-  # check was written was not yet released. So instead we rely on a
-  # nightly version.
+  # We still want to be able to test out the library on newer Scala version.
+  # For those version, we compile the library using 3.2 and then run the tests
+  # against the newer version. This effectively emulate what our users are doing.
   test-newer:
     name: Test (${{ matrix.scalaV }})
     runs-on: ubuntu-latest
@@ -50,11 +50,15 @@ jobs:
       fail-fast: false
       matrix:
         scalaV:
-          - "3.4.0-RC1-bin-20230909-64c3138-NIGHTLY"
+          - "3.3.3"
+          - "3.4.2"
+          - "3.5.0-RC1"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
-      - run: sbt '++${{ matrix.scalaV }}! test'
+      - run: |
+          sbt 'core/publishLocal'
+          sbt '++${{ matrix.scalaV }}! test'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -61,4 +61,4 @@ jobs:
           java-version: '11'
       - run: |
           sbt 'core/publishLocal'
-          sbt '++${{ matrix.scalaV }}! test'
+          sbt '++${{ matrix.scalaV }}! integration/test'

--- a/build.sbt
+++ b/build.sbt
@@ -74,3 +74,24 @@ lazy val docs = project
     ),
     libraryDependencies += "org.typelevel" %% "cats-effect" % "3.5.4"
   )
+
+/* This project is a bit particular in how it operates. Because compiling the library itself
+  is restricted to 3.2.x at the moment, we cannot use the regular cross compilation scheme for
+  testing. Instead, what we do is that we compile the library using 3.2.2, and then depend on
+  that compiled jar in the integration tests using more recent version of the compiler.
+
+  This project is only used to provide this integration point (the src directory only contain
+  a symlink to the core tests). See the GitHub Actions to see how to use it.
+
+ */
+lazy val integration = project
+  .in(file("./integration"))
+  .settings(
+    name := "scala3mock-integration-tests",
+
+    crossScalaVersions := Seq("3.3.3", "3.4.0", "3.5.0-RC1"),
+
+    // Note that this means we need to publish core via publishLocal first.
+    libraryDependencies += "eu.monniot" %% "scala3mock" % version.value % Test,
+    libraryDependencies += "org.scalameta" %% "munit" % "1.0.0-M11" % Test,
+  )

--- a/integration/src/test
+++ b/integration/src/test
@@ -1,0 +1,1 @@
+../../core/src/test


### PR DESCRIPTION
While we cannot compile the library on 3.3+ without suffering some issues (the main one being the `experimental` flag required), we can certainly test the usage of the library across all Scala versions.

This should help provide some confidence that the library indeed work across the board.