### PR TITLE
Add assertions for using/context bound

### DIFF
--- a/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
+++ b/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
@@ -91,7 +91,7 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
 
       given cb: ContextBound[String] = new ContextBound {}
 
-      when(m.contextBound(_: String)(_: ContextBound[String]))
+      when(m.contextBound(_: String)(using _: ContextBound[String]))
         .expects("arg", cb)
         .returning("ok")
       assertEquals(m.contextBound("arg"), "ok")

--- a/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
+++ b/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
@@ -84,6 +84,18 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
         .returning("it works")
       assertEquals(m.implicitParam(42), "it works")
 
+      when(m.usingParam(_: Int)(using _: Double))
+        .expects(43, 1.23)
+        .returning("ok")
+      assertEquals(m.usingParam(43), "ok")
+
+      given cb: ContextBound[String] = new ContextBound {}
+
+      when(m.contextBound(_: String)(_: ContextBound[String]))
+        .expects("arg", cb)
+        .returning("ok")
+      assertEquals(m.contextBound("arg"), "ok")
+
       // type bound methods
       when(m.upperBound _).expects(TestException()).returns(1)
       assertEquals(m.upperBound(TestException()), 1)

--- a/core/src/test/scala/fixtures/TestTrait.scala
+++ b/core/src/test/scala/fixtures/TestTrait.scala
@@ -26,8 +26,6 @@ trait TestTrait {
   def repeatedParam(x: Int, ys: String*): String
   def byNameParam(x: => Int): String
 
-  // Can't do those two because Scala 3 doesn't seems to offer a way
-  // to specify if a parameter list has a modifier or not.
   def implicitParam(x: Int)(implicit y: Double): String
   def usingParam(x: Int)(using y: Double): String
   def contextBound[T: ContextBound](x: T): String


### PR DESCRIPTION
And remove an outdated comment. I think that got fixed when the library changed how it obtain the type of the override. I did enabled the `implicitParam` case but forgot to do the `using` and context bound ones. This is now rectified.