### PR TITLE
Can properly set expectation when a private overloaded method exists

### DIFF
--- a/core/src/main/scala/eu/monniot/scala3mock/macros/WhenImpl.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/macros/WhenImpl.scala
@@ -117,7 +117,7 @@ private[scala3mock] object WhenImpl:
             name
 
           case Some(signature) =>
-            classSymbol.map(_.methodMembers) match
+            classSymbol.map(utils.findMethodsToOverride) match
               case None =>
                 report.errorAndAbort(
                   "The when parameter is composed of more than one type, which isn't supported at the moment."

--- a/core/src/main/scala/eu/monniot/scala3mock/macros/utils.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/macros/utils.scala
@@ -12,3 +12,38 @@ private[macros] object utils:
       val sig = sym.signature
       sig.resultSig + sig.paramSigs.map(_.toString()).mkString
     }
+
+  def findMethodsToOverride(using quotes: Quotes)(
+      sym: quotes.reflect.Symbol
+  ): List[quotes.reflect.Symbol] =
+    import quotes.reflect.*
+
+    val objectMembers = Symbol.requiredClass("java.lang.Object").methodMembers
+    val anyMembers = Symbol.requiredClass("scala.Any").methodMembers
+
+    // First we refine the methods by removing the methods inherited from Object and Any
+    val candidates = sym.methodMembers
+      .filter { m =>
+        !(objectMembers.contains(m) || anyMembers.contains(m))
+      }
+      .filterNot(_.flags.is(Flags.Private)) // Do not override private members
+
+    // We then generate a list of methods to ignore for default values. We do this because the
+    // compiler generate methods (following the `<methodName>$default$<parameterPosition>` naming
+    // scheme) to hold the default value of a parameter (and insert them automatically at call site).
+    // We do not want to override those.
+    val namesToIgnore = candidates
+      .flatMap { sym =>
+        sym.paramSymss
+          .filterNot(_.exists(_.isType))
+          .flatten
+          .zipWithIndex
+          .collect {
+            case (parameter, position)
+                if parameter.flags.is(Flags.HasDefault) =>
+              s"${sym.name}$$default$$${position + 1}"
+          }
+      }
+
+    candidates.filterNot(m => namesToIgnore.contains(m.name))
+  end findMethodsToOverride

--- a/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
+++ b/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
@@ -332,4 +332,18 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
       assertEquals(m.multiParamList(1)(1), "default")
     }
   }
+
+  test("overloaded private method - issue #68") {
+    class Service {
+      def method(value: String): String = method(2, true)
+      private def method(value: Int, value2: Boolean): String = "nok"
+    }
+
+    withExpectations() {
+      val service = mock[Service]
+
+      when(service.method).expects("").returns("ok")
+      assertEquals(service.method(""), "ok")
+    }
+  }
 }


### PR DESCRIPTION
This should fix #68. When I added support for private method overload, I forgot to add the same filtering logic in the `when` macro.