### PR TITLE
Try making it easier to see what version was published

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,6 +40,11 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - run: sbt test
+      - name: Print published version
+        run: >
+          VERSION=$(sbt 'inspect actual version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
+          echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
+          echo 'version: $VERSION' >> $GITHUB_STEP_SUMMARY
   # We still want to be able to test out the library on newer Scala version.
   # For those version, we compile the library using 3.2 and then run the tests
   # against the newer version. This effectively emulate what our users are doing.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,20 +45,13 @@ jobs:
       - run: sbt 'inspect version'
       - name: Print published version
         run: >
-          TXT=$(sbt 'inspect version')
-          echo $TXT
-          echo '-----------'
-          TXT=$(sbt 'inspect version' | grep 'Setting:')
-          echo $TXT
-          echo '-----------'
-          TXT=$(sbt 'inspect version' | grep 'Setting:' | cut -d '=' -f2)
-          echo $TXT
-          echo '-----------'
+        echo ----------- TXT=[info] Setting: java.lang.String = 0.6.3+18-8c53acad-SNAPSHOT echo echo ----------- TXT= 0.6.3+18-8c53acad-SNAPSHOT echo echo ----------- TXT=0.6.3+18-8c53acad-SNAPSHOT echo echo -----------
           TXT=$(sbt 'inspect version' | grep 'Setting:' | cut -d '=' -f2 | tr -d ' ')
           echo $TXT
-          echo '-----------'
+          echo "-----------\n"
 
           VERSION=$(sbt 'inspect version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
+          echo $VERSION
           echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
           echo "version: $VERSION" >> $GITHUB_STEP_SUMMARY
   # We still want to be able to test out the library on newer Scala version.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,6 +40,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - run: sbt test
+      - run: sbt 'inspect actual version'
       - name: Print published version
         run: >
           VERSION=$(sbt 'inspect actual version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,10 +42,23 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - run: sbt test
-      - run: sbt 'inspect actual version'
+      - run: sbt 'inspect version'
       - name: Print published version
         run: >
-          VERSION=$(sbt 'inspect actual version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
+          TXT=$(sbt 'inspect version')
+          echo $TXT
+          echo '-----------'
+          TXT=$(sbt 'inspect version' | grep 'Setting:')
+          echo $TXT
+          echo '-----------'
+          TXT=$(sbt 'inspect version' | grep 'Setting:' | cut -d '=' -f2)
+          echo $TXT
+          echo '-----------'
+          TXT=$(sbt 'inspect version' | grep 'Setting:' | cut -d '=' -f2 | tr -d ' ')
+          echo $TXT
+          echo '-----------'
+
+          VERSION=$(sbt 'inspect version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
           echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
           echo "version: $VERSION" >> $GITHUB_STEP_SUMMARY
   # We still want to be able to test out the library on newer Scala version.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,19 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
-      #- run: sbt test
-      - run: sbt 'inspect version'
-      - name: Print published version
-        run: |
-          VERSION=$(sbt -no-colors 'inspect version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
-          echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
-          echo "version: $VERSION" >> $GITHUB_STEP_SUMMARY
+      - run: sbt test
   # We still want to be able to test out the library on newer Scala version.
   # For those version, we compile the library using 3.2 and then run the tests
   # against the newer version. This effectively emulate what our users are doing.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,7 +45,7 @@ jobs:
       - run: sbt 'inspect version'
       - name: Print published version
         run: >
-        echo ----------- TXT=[info] Setting: java.lang.String = 0.6.3+18-8c53acad-SNAPSHOT echo echo ----------- TXT= 0.6.3+18-8c53acad-SNAPSHOT echo echo ----------- TXT=0.6.3+18-8c53acad-SNAPSHOT echo echo -----------
+          echo ----------- TXT=[info] Setting: java.lang.String = 0.6.3+18-8c53acad-SNAPSHOT echo echo ----------- TXT= 0.6.3+18-8c53acad-SNAPSHOT echo echo ----------- TXT=0.6.3+18-8c53acad-SNAPSHOT echo echo -----------
           TXT=$(sbt 'inspect version' | grep 'Setting:' | cut -d '=' -f2 | tr -d ' ')
           echo $TXT
           echo "-----------\n"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,7 +44,7 @@ jobs:
         run: >
           VERSION=$(sbt 'inspect actual version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
           echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
-          echo 'version: $VERSION' >> $GITHUB_STEP_SUMMARY
+          echo "version: $VERSION" >> $GITHUB_STEP_SUMMARY
   # We still want to be able to test out the library on newer Scala version.
   # For those version, we compile the library using 3.2 and then run the tests
   # against the newer version. This effectively emulate what our users are doing.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,14 +45,7 @@ jobs:
       - run: sbt 'inspect version'
       - name: Print published version
         run: |
-          TXT=$(sbt 'inspect version' | grep 'Setting:' | cut -d '=' -f2 | tr -d ' ')
-          echo b------------
-          echo $TXT
-          echo a-----------
-
-          VERSION=$(sbt 'inspect version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
-          echo version
-          echo $VERSION
+          VERSION=$(sbt -no-colors 'inspect version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
           echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
           echo "version: $VERSION" >> $GITHUB_STEP_SUMMARY
   # We still want to be able to test out the library on newer Scala version.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,16 +41,17 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - run: sbt test
+      #- run: sbt test
       - run: sbt 'inspect version'
       - name: Print published version
-        run: >
-          echo ----------- TXT=[info] Setting: java.lang.String = 0.6.3+18-8c53acad-SNAPSHOT echo echo ----------- TXT= 0.6.3+18-8c53acad-SNAPSHOT echo echo ----------- TXT=0.6.3+18-8c53acad-SNAPSHOT echo echo -----------
+        run: |
           TXT=$(sbt 'inspect version' | grep 'Setting:' | cut -d '=' -f2 | tr -d ' ')
+          echo b------------
           echo $TXT
-          echo "-----------\n"
+          echo a-----------
 
           VERSION=$(sbt 'inspect version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
+          echo version
           echo $VERSION
           echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
           echo "version: $VERSION" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Check git diff
         if: ${{ failure() }}
         run: git diff
+      - name: Print published version
+        if: github.ref == 'refs/heads/main'
+        run: >
+          VERSION=$(sbt 'inspect actual version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
+          echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
+          echo 'version: $VERSION' >> $GITHUB_STEP_SUMMARY
 
   website:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           VERSION=$(sbt -no-colors 'inspect version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
-          echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
+          echo '### Snapshot version' >> $GITHUB_STEP_SUMMARY
           echo "version: $VERSION" >> $GITHUB_STEP_SUMMARY
 
   website:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: >
           VERSION=$(sbt 'inspect actual version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
           echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
-          echo 'version: $VERSION' >> $GITHUB_STEP_SUMMARY
+          echo "version: $VERSION" >> $GITHUB_STEP_SUMMARY
 
   website:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
         run: git diff
       - name: Print published version
         if: github.ref == 'refs/heads/main'
-        run: >
-          VERSION=$(sbt 'inspect actual version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
+        run: |
+          VERSION=$(sbt -no-colors 'inspect version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
           echo '### Snapshot published !' >> $GITHUB_STEP_SUMMARY
           echo "version: $VERSION" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
Currently to find out the latest snapshot version, one has to go look on sonatype (not easy for snapshots) or in the github action logs. Let's try to make that a bit easier by adding the version as a summary.

The `checks.yml` change is only to test out the action change and will be removed before merging.