### PR TITLE
add MatchPredicate up to 22 params

### DIFF
--- a/core/src/main/scala/eu/monniot/scala3mock/matchers/MatchPredicate.scala
+++ b/core/src/main/scala/eu/monniot/scala3mock/matchers/MatchPredicate.scala
@@ -2,42 +2,112 @@ package eu.monniot.scala3mock.matchers
 
 import eu.monniot.scala3mock.functions.*
 
+// format: off
 trait MatchPredicate:
   def where[T1](matcher: T1 => Boolean): FunctionAdapter1[T1, Boolean] =
     FunctionAdapter1(matcher)
+  
   def where[T1, T2](
       matcher: (T1, T2) => Boolean
   ): FunctionAdapter2[T1, T2, Boolean] = FunctionAdapter2(matcher)
+  
   def where[T1, T2, T3](
       matcher: (T1, T2, T3) => Boolean
   ): FunctionAdapter3[T1, T2, T3, Boolean] = FunctionAdapter3(matcher)
+  
   def where[T1, T2, T3, T4](
       matcher: (T1, T2, T3, T4) => Boolean
   ): FunctionAdapter4[T1, T2, T3, T4, Boolean] = FunctionAdapter4(matcher)
+  
   def where[T1, T2, T3, T4, T5](
       matcher: (T1, T2, T3, T4, T5) => Boolean
   ): FunctionAdapter5[T1, T2, T3, T4, T5, Boolean] = FunctionAdapter5(matcher)
+  
   def where[T1, T2, T3, T4, T5, T6](
       matcher: (T1, T2, T3, T4, T5, T6) => Boolean
   ): FunctionAdapter6[T1, T2, T3, T4, T5, T6, Boolean] = FunctionAdapter6(
     matcher
   )
+  
   def where[T1, T2, T3, T4, T5, T6, T7](
       matcher: (T1, T2, T3, T4, T5, T6, T7) => Boolean
   ): FunctionAdapter7[T1, T2, T3, T4, T5, T6, T7, Boolean] = FunctionAdapter7(
     matcher
   )
+  
   def where[T1, T2, T3, T4, T5, T6, T7, T8](
       matcher: (T1, T2, T3, T4, T5, T6, T7, T8) => Boolean
   ): FunctionAdapter8[T1, T2, T3, T4, T5, T6, T7, T8, Boolean] =
     FunctionAdapter8(matcher)
+  
   def where[T1, T2, T3, T4, T5, T6, T7, T8, T9](
       matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => Boolean
   ): FunctionAdapter9[T1, T2, T3, T4, T5, T6, T7, T8, T9, Boolean] =
     FunctionAdapter9(matcher)
+  
   def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](
       matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => Boolean
   ): FunctionAdapter10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Boolean] =
     FunctionAdapter10(matcher)
+  
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => Boolean
+  ): FunctionAdapter11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Boolean] =
+    FunctionAdapter11(matcher)
+  
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => Boolean
+  ): FunctionAdapter12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Boolean] =
+    FunctionAdapter12(matcher)
+  
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => Boolean
+  ): FunctionAdapter13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Boolean] =
+    FunctionAdapter13(matcher)
+  
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => Boolean
+  ): FunctionAdapter14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Boolean] =
+    FunctionAdapter14(matcher)
 
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => Boolean
+  ): FunctionAdapter15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Boolean] =
+    FunctionAdapter15(matcher)
+
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => Boolean
+  ): FunctionAdapter16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Boolean] =
+    FunctionAdapter16(matcher)
+
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => Boolean
+  ): FunctionAdapter17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, Boolean] =
+    FunctionAdapter17(matcher)
+
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => Boolean
+  ): FunctionAdapter18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, Boolean] =
+    FunctionAdapter18(matcher)
+
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => Boolean
+  ): FunctionAdapter19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, Boolean] =
+    FunctionAdapter19(matcher)
+
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => Boolean
+  ): FunctionAdapter20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, Boolean] =
+    FunctionAdapter20(matcher)
+
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => Boolean
+  ): FunctionAdapter21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, Boolean] =
+    FunctionAdapter21(matcher)
+
+  def where[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](
+      matcher: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => Boolean
+  ): FunctionAdapter22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, Boolean] =
+    FunctionAdapter22(matcher)
+// format: on
 object MatchPredicate extends MatchPredicate

--- a/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
+++ b/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
@@ -347,42 +347,42 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
 
       val mock9 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock9.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9
       }).returning(())
       mock9(1, 2, 3, 4, 5, 6, 7, 8, 9)
 
       val mock10 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock10.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10
       }).returning(())
       mock10(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 
       val mock11 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock11.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11
       }).returning(())
       mock11(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
 
       val mock12 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock12.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12
       }).returning(())
       mock12(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
 
       val mock13 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock13.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13
       }).returning(())
       mock13(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
 
       val mock14 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock14.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
             v14 == 14
       }).returning(())
@@ -390,7 +390,7 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
 
       val mock15 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock15.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
             v14 == 14 && v15 == 15
       }).returning(())
@@ -398,7 +398,7 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
 
       val mock16 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock16.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
             v14 == 14 && v15 == 15 && v16 == 16
       }).returning(())
@@ -406,7 +406,7 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
 
       val mock17 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock17.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
             v14 == 14 && v15 == 15 && v16 == 16 && v17 == 17
       }).returning(())
@@ -414,7 +414,7 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
 
       val mock18 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock18.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
             v14 == 14 && v15 == 15 && v16 == 16 && v17 == 17 && v18 == 18
       }).returning(())
@@ -422,7 +422,7 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
 
       val mock19 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock19.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int, v19: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int, v19: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
             v14 == 14 && v15 == 15 && v16 == 16 && v17 == 17 && v18 == 18 && v19 == 19
       }).returning(())
@@ -430,7 +430,7 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
 
       val mock20 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock20.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int, v19: Int, v20: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int, v19: Int, v20: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
             v14 == 14 && v15 == 15 && v16 == 16 && v17 == 17 && v18 == 18 && v19 == 19 && v20 == 20
       }).returning(())
@@ -438,7 +438,7 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
 
       val mock21 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
       mock21.expects(where {
-        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int, v19: Int, v20: Int, v21: Int) => 
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int, v19: Int, v20: Int, v21: Int) =>
           v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
             v14 == 14 && v15 == 15 && v16 == 16 && v17 == 17 && v18 == 18 && v19 == 19 && v20 == 20 && v21 == 21
       }).returning(())

--- a/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
+++ b/core/src/test/scala/eu/monniot/scala3mock/mock/MockSuite.scala
@@ -294,6 +294,159 @@ class MockSuite extends munit.FunSuite with ScalaMocks {
     }
   }
 
+  test("Match predicate") {
+    withExpectations() {
+      // format: off
+      val mock1 = mockFunction[Int, Unit]
+      mock1.expects(where {
+        (v1: Int) => v1 == 1
+      }).returning(())
+      mock1(1)
+
+      val mock2 = mockFunction[Int, Int, Unit]
+      mock2.expects(where {
+        (v1: Int, v2: Int) => v1 == 1 && v2 == 2
+      }).returning(())
+      mock2(1, 2)
+
+      val mock3 = mockFunction[Int, Int, Int, Unit]
+      mock3.expects(where {
+        (v1: Int, v2: Int, v3: Int) => v1 == 1 && v2 == 2 && v3 == 3
+      }).returning(())
+      mock3(1, 2, 3)
+
+      val mock4 = mockFunction[Int, Int, Int, Int, Unit]
+      mock4.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int) => v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4
+      }).returning(())
+      mock4(1, 2, 3, 4)
+
+      val mock5 = mockFunction[Int, Int, Int, Int, Int, Unit]
+      mock5.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int) => v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5
+      }).returning(())
+      mock5(1, 2, 3, 4, 5)
+
+      val mock6 = mockFunction[Int, Int, Int, Int, Int, Int, Unit]
+      mock6.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int) => v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6
+      }).returning(())
+      mock6(1, 2, 3, 4, 5, 6)
+
+      val mock7 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock7.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int) => v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7
+      }).returning(())
+      mock7(1, 2, 3, 4, 5, 6, 7)
+
+      val mock8 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock8.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int) => v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8
+      }).returning(())
+      mock8(1, 2, 3, 4, 5, 6, 7, 8)
+
+      val mock9 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock9.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9
+      }).returning(())
+      mock9(1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+      val mock10 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock10.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10
+      }).returning(())
+      mock10(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+
+      val mock11 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock11.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11
+      }).returning(())
+      mock11(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+
+      val mock12 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock12.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12
+      }).returning(())
+      mock12(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+
+      val mock13 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock13.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13
+      }).returning(())
+      mock13(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+
+      val mock14 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock14.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
+            v14 == 14
+      }).returning(())
+      mock14(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
+
+      val mock15 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock15.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
+            v14 == 14 && v15 == 15
+      }).returning(())
+      mock15(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+
+      val mock16 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock16.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
+            v14 == 14 && v15 == 15 && v16 == 16
+      }).returning(())
+      mock16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+
+      val mock17 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock17.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
+            v14 == 14 && v15 == 15 && v16 == 16 && v17 == 17
+      }).returning(())
+      mock17(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)
+
+      val mock18 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock18.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
+            v14 == 14 && v15 == 15 && v16 == 16 && v17 == 17 && v18 == 18
+      }).returning(())
+      mock18(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18)
+
+      val mock19 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock19.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int, v19: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
+            v14 == 14 && v15 == 15 && v16 == 16 && v17 == 17 && v18 == 18 && v19 == 19
+      }).returning(())
+      mock19(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)
+
+      val mock20 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock20.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int, v19: Int, v20: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
+            v14 == 14 && v15 == 15 && v16 == 16 && v17 == 17 && v18 == 18 && v19 == 19 && v20 == 20
+      }).returning(())
+      mock20(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
+
+      val mock21 = mockFunction[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Unit]
+      mock21.expects(where {
+        (v1: Int, v2: Int, v3: Int, v4: Int, v5: Int, v6: Int, v7: Int, v8: Int, v9: Int, v10: Int, v11: Int, v12: Int, v13: Int, v14: Int, v15: Int, v16: Int, v17: Int, v18: Int, v19: Int, v20: Int, v21: Int) => 
+          v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4 && v5 == 5 && v6 == 6 && v7 == 7 && v8 == 8 && v9 == 9 && v10 == 10 && v11 == 11 && v12 == 12 && v13 == 13 &&
+            v14 == 14 && v15 == 15 && v16 == 16 && v17 == 17 && v18 == 18 && v19 == 19 && v20 == 20 && v21 == 21
+      }).returning(())
+      mock21(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
+      // format: off
+    }
+  }
+
   test("ManyParams") {
     withExpectations() {
       val m = mock[ManyParamsTrait]


### PR DESCRIPTION
obviously I forgot something in the previous PR, good that I found it out.
Here we have a `where` support for up to 22 params and tests for it